### PR TITLE
fix: make CPU stats portable (drop Unix-only resource module)

### DIFF
--- a/src/histserv/service.py
+++ b/src/histserv/service.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import resource
+import os
 import time
 import typing as tp
 import uuid
@@ -285,7 +285,7 @@ class Histogrammer(hist_pb2_grpc.HistogrammerServiceServicer):
                 },
             )
 
-        usage = resource.getrusage(resource.RUSAGE_SELF)
+        times = os.times()
         observed_at = datetime.now(timezone.utc)
         return StatsSnapshot(
             histogram_count=len(entries),
@@ -293,8 +293,8 @@ class Histogrammer(hist_pb2_grpc.HistogrammerServiceServicer):
             active_rpcs=self._active_rpcs,
             version=__version__,
             uptime_seconds=int((observed_at - self._started_at).total_seconds()),
-            user_cpu_seconds=usage.ru_utime,
-            system_cpu_seconds=usage.ru_stime,
+            user_cpu_seconds=times.user,
+            system_cpu_seconds=times.system,
             rpc_calls_total=dict(self._rpc_calls_total),
             observed_at=observed_at,
             token_scoped=token_scoped,


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Problem

`src/histserv/service.py` imported the `resource` module at the top level. The `resource` module is Unix-only (POSIX) and does not exist on Windows. This caused an `ImportError` when importing `histserv.service` on Windows — making the server entirely unusable on that platform — despite `pyproject.toml` declaring `Operating System :: OS Independent` and gRPC itself supporting Windows.

## Fix

Replace the single use of `resource.getrusage(resource.RUSAGE_SELF)` in `Histogrammer._compute_stats` with the cross-platform `os.times()`. `os.times()` returns a named tuple with `.user` and `.system` fields representing process CPU times, and works on all platforms including Windows. `os` was not previously imported; `import resource` is removed and `import os` added in its place.

The behavior on Unix is equivalent: both interfaces measure the same process user- and system-CPU time.

Part of #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
