### PR TITLE
fix: avoid data loss when Snapshot(delete_from_server) serialization fails

### DIFF
--- a/src/histserv/service.py
+++ b/src/histserv/service.py
@@ -543,7 +543,7 @@ class Histogrammer(hist_pb2_grpc.HistogrammerServiceServicer):
                     )
 
                 if request.delete_from_server:
-                    snapshot = self._entries.pop(hist_id).hist
+                    snapshot = entry.hist
                 elif request.chunk_selectors:
                     selection: dict[str, list[str | int]] = {}
                     for selector in request.chunk_selectors:
@@ -561,6 +561,12 @@ class Histogrammer(hist_pb2_grpc.HistogrammerServiceServicer):
                 else:
                     snapshot = entry.hist
 
+                payload = serialize_chunked_hist_payload(
+                    snapshot,
+                    codec=self._request_dense_view_codec(request),
+                )
+                if request.delete_from_server:
+                    self._entries.pop(hist_id, None)
                 logger.debug(
                     fmt_rpc_logger_msg(
                         rpc_method=RPC_SNAPSHOT,
@@ -568,12 +574,7 @@ class Histogrammer(hist_pb2_grpc.HistogrammerServiceServicer):
                         msg="created snapshot",
                     )
                 )
-                return hist_pb2.SnapshotResponse(
-                    payload=serialize_chunked_hist_payload(
-                        snapshot,
-                        codec=self._request_dense_view_codec(request),
-                    )
-                )
+                return hist_pb2.SnapshotResponse(payload=payload)
             except (TypeError, ValueError) as exc:
                 logger.error(
                     fmt_rpc_logger_msg(


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Bug

When `Snapshot` is called with `delete_from_server=True`, the previous code did:

```python
snapshot = self._entries.pop(hist_id).hist
```

This removed the entry from `_entries` **before** serializing it. If `serialize_chunked_hist_payload(...)` subsequently raised a `TypeError` or `ValueError` (caught by the existing `except` block), the RPC returned `FAILED_PRECONDITION` — but the histogram was already gone from the server. The client received an error **and** the data was permanently lost.

## Fix

Serialize first, pop second:

1. Set `snapshot = entry.hist` (no pop yet).
2. Call `serialize_chunked_hist_payload(...)` to build the payload.
3. Only after that returns successfully, call `self._entries.pop(hist_id, None)` guarded by `if request.delete_from_server:`.
4. Return the `SnapshotResponse`.

If serialization fails, the entry is still in `_entries` and the client can retry or recover.

## Tests

All 55 existing integration tests pass, including `test_snapshot_delete_from_server_removes_hist` which covers the happy-path ordering (data returned + entry removed).

Part of #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
