### PR TITLE
chore: document categorical-flow limitation and tidy byte formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ Unsupported today:
 - transformed `hist.axis.Regular`
 - `boost_histogram.storage.Mean`
 - `boost_histogram.storage.WeightedMean`
+- overflow bins on `IntCategory`/`StrCategory` chunk axes are not preserved
+  across `from_hist()`/`to_hist()` (categorical overflow is silently dropped)
 
 Notes:
 - Growable categorical axes (`IntCategory`, `StrCategory`) are treated as

--- a/src/histserv/chunked_hist.py
+++ b/src/histserv/chunked_hist.py
@@ -256,6 +256,10 @@ class ChunkedHist:
         if not any(spec.known_keys for spec in chunked.chunk_axes):
             return chunked
 
+        # Only the real category positions (0..n-1) are addressed here; the
+        # categorical overflow bin (index -1 when flow=True) is never read.
+        # If the source histogram had overflow fills on an IntCategory/StrCategory
+        # axis, those counts are silently dropped and will not appear in the result.
         for key_indices in itertools.product(
             *(range(len(spec.known_keys)) for spec in chunked.chunk_axes)
         ):
@@ -417,6 +421,9 @@ class ChunkedHist:
             for spec in self.chunk_axes
         ]
 
+        # Each chunk key maps to a real category index (0..n-1); the categorical
+        # overflow bin is never written. Any overflow counts that existed before
+        # a from_hist() call were already dropped at that point.
         for key, chunk_view in self._chunks.items():
             selector: list[tp.Any] = [slice(None)] * merged_view.ndim
             for spec, axis_map, key_part in zip(

--- a/src/histserv/util.py
+++ b/src/histserv/util.py
@@ -27,11 +27,11 @@ def bytes_repr(num_bytes: int) -> str:
     """
     count, units = (
         (f"{num_bytes / 1e9:,.2f}", "GB")
-        if num_bytes > 1e9
+        if num_bytes >= 1e9
         else (f"{num_bytes / 1e6:,.2f}", "MB")
-        if num_bytes > 1e6
+        if num_bytes >= 1e6
         else (f"{num_bytes / 1e3:,.2f}", "KB")
-        if num_bytes > 1e3
+        if num_bytes >= 1e3
         else (f"{num_bytes:,}", "B")
     )
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

This PR contains two small, low-risk cleanup changes.

## Change A — document categorical-flow limitation

`ChunkedHist.from_hist` iterates over `range(len(spec.known_keys))` for each chunk axis, so it only addresses real category positions (0..n-1) in the source view. The categorical overflow bin (index -1 when `flow=True`) is never read. Likewise, `to_hist` writes each chunk key to its integer index but never touches the overflow slot.

This means that if an `IntCategory` or `StrCategory` axis was created with `flow=True` and received overflow fills, those counts are silently dropped on the `from_hist` → `to_hist` round-trip — even though `ChunkAxisSpec` records the `flow` flag.

No fix is attempted (out of scope / risky). Instead:
- Added concise comments at the relevant loop in `from_hist` and the write loop in `to_hist` in `src/histserv/chunked_hist.py`.
- Added a one-line entry to the "Unsupported today" section in `README.md`.

## Change B — tidy byte-formatting boundaries

`bytes_repr` in `src/histserv/util.py` used strict `>` comparisons for unit thresholds, while the adjacent `duration_repr` already uses `>=`. This caused a value of exactly 1000 bytes to render as `'1,000 B'` instead of the cleaner `'1.00 KB'`. Changed `>` to `>=` for all three thresholds to make the behaviour consistent and correct at boundary values. The existing docstring example (`bytes_repr(1536)` → `'1.54 KB'`) is unaffected.

Part of #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
