### PR TITLE
fix: enforce access tokens on dashboard WebSocket endpoints

### DIFF
--- a/src/histserv/dashboard/bridge.py
+++ b/src/histserv/dashboard/bridge.py
@@ -18,7 +18,7 @@ from histserv.dashboard.histogram_json import (
     histogram_summary,
     histogram_to_plot_json,
 )
-from histserv.service import Histogrammer
+from histserv.service import HistogramEntry, Histogrammer
 
 # Interval constants (seconds)
 _STATS_INTERVAL = 1.0
@@ -50,10 +50,31 @@ class _ClientState:
     last_hist_push: dict[_HistRequest, float] = field(default_factory=dict)
     # last version (ms timestamp) sent per request, to skip redundant pushes
     last_hist_version: dict[_HistRequest, int] = field(default_factory=dict)
+    # access token for this connection (mirrors the REST ?token= convention);
+    # gates visibility of token-protected histograms
+    token: str | None = None
 
 
 def _envelope(msg_type: str, payload: dict) -> dict:
     return {"type": msg_type, "ts": time.time(), "payload": payload}
+
+
+def _visible_entry(
+    histogrammer: Histogrammer, hist_id: str, token: str | None
+) -> HistogramEntry | None:
+    """Resolve a histogram entry honoring token-based access control.
+
+    Mirrors the gRPC server's ``_get_entry``: a token-protected entry is only
+    visible to a caller presenting the matching token. Returns ``None`` (i.e.
+    "not found") on a missing entry or a token mismatch, so REST and WS callers
+    can't distinguish "doesn't exist" from "no access".
+    """
+    entry = histogrammer._entries.get(hist_id)
+    if entry is None:
+        return None
+    if entry.token is not None and entry.token != token:
+        return None
+    return entry
 
 
 def create_app(
@@ -79,10 +100,8 @@ def create_app(
     async def get_histogram_metadata(
         hist_id: str, token: str | None = None
     ) -> JSONResponse:
-        entry = histogrammer._entries.get(hist_id)
+        entry = _visible_entry(histogrammer, hist_id, token)
         if entry is None:
-            return JSONResponse({"error": "not found"}, status_code=404)
-        if entry.token is not None and entry.token != token:
             return JSONResponse({"error": "not found"}, status_code=404)
         try:
             data = histogram_metadata(hist_id, entry)
@@ -94,16 +113,15 @@ def create_app(
     async def get_histogram(
         hist_id: str, token: str | None = None, selection: str | None = None
     ) -> JSONResponse:
-        entry = histogrammer._entries.get(hist_id)
+        entry = _visible_entry(histogrammer, hist_id, token)
         if entry is None:
-            return JSONResponse({"error": "not found"}, status_code=404)
-        if entry.token is not None and entry.token != token:
             return JSONResponse({"error": "not found"}, status_code=404)
         try:
             hist_request = _make_hist_request(
                 hist_id,
                 _parse_selection_query(selection),
                 histogrammer,
+                token,
             )
             data = await asyncio.to_thread(
                 histogram_to_plot_json,
@@ -120,9 +138,9 @@ def create_app(
         return JSONResponse(data)
 
     @app.websocket("/ws")
-    async def ws_endpoint(websocket: WebSocket) -> None:
+    async def ws_endpoint(websocket: WebSocket, token: str | None = None) -> None:
         await websocket.accept()
-        state = _ClientState(websocket=websocket)
+        state = _ClientState(websocket=websocket, token=token)
         _clients.add(state)
         try:
             while True:
@@ -181,8 +199,9 @@ def _make_hist_request(
     hist_id: str,
     raw_selection: object,
     histogrammer: Histogrammer,
+    token: str | None,
 ) -> _HistRequest:
-    entry = histogrammer._entries.get(hist_id)
+    entry = _visible_entry(histogrammer, hist_id, token)
     if entry is None:
         raise KeyError(hist_id)
 
@@ -236,6 +255,7 @@ async def _handle_client_message(
                     hist_id,
                     payload.get("selection"),
                     histogrammer,
+                    state.token,
                 )
             except KeyError:
                 await _send_ws_error(
@@ -295,6 +315,7 @@ async def _handle_client_message(
                     hist_id,
                     payload.get("selection"),
                     histogrammer,
+                    state.token,
                 )
             except KeyError:
                 await _send_ws_error(
@@ -339,7 +360,7 @@ async def _push_to_client(
         if now - last < min_interval:
             continue
 
-        entry = histogrammer._entries.get(hist_request.hist_id)
+        entry = _visible_entry(histogrammer, hist_request.hist_id, state.token)
         if entry is None:
             await _send_ws_error(
                 state,
@@ -381,6 +402,7 @@ async def _send_hist_list(state: _ClientState, histogrammer: Histogrammer) -> No
     items = [
         histogram_summary(hist_id, entry)
         for hist_id, entry in histogrammer._entries.items()
+        if entry.token is None or entry.token == state.token
     ]
     await state.websocket.send_json(_envelope("hist_list", {"items": items}))
 
@@ -388,7 +410,7 @@ async def _send_hist_list(state: _ClientState, histogrammer: Histogrammer) -> No
 async def _send_hist_meta(
     state: _ClientState, hist_id: str, histogrammer: Histogrammer
 ) -> None:
-    entry = histogrammer._entries.get(hist_id)
+    entry = _visible_entry(histogrammer, hist_id, state.token)
     if entry is None:
         await _send_ws_error(
             state,
@@ -404,7 +426,7 @@ async def _send_hist_meta(
 async def _send_hist_data(
     state: _ClientState, hist_request: _HistRequest, histogrammer: Histogrammer
 ) -> None:
-    entry = histogrammer._entries.get(hist_request.hist_id)
+    entry = _visible_entry(histogrammer, hist_request.hist_id, state.token)
     if entry is None:
         await _send_ws_error(
             state,

--- a/tests/test_dashboard/test_bridge_ws.py
+++ b/tests/test_dashboard/test_bridge_ws.py
@@ -24,13 +24,15 @@ def app_client(histogrammer: Histogrammer) -> TestClient:
     return TestClient(app)
 
 
-def _add_hist(histogrammer: Histogrammer, h: hist.Hist) -> str:
+def _add_hist(
+    histogrammer: Histogrammer, h: hist.Hist, token: str | None = None
+) -> str:
     import uuid
 
     hist_id = uuid.uuid4().hex
     histogrammer._entries[hist_id] = HistogramEntry(
         hist=ChunkedHist.from_hist(h),
-        token=None,
+        token=token,
         last_access=datetime.now(timezone.utc),
         unique_ids=set(),
     )
@@ -197,6 +199,57 @@ class TestWebSocketProtocol:
             ws.send_json({"type": "subscribe", "payload": {"streams": ["stats"]}})
             msg2 = ws.receive_json()
             assert msg2["type"] == "stats"
+
+    def test_token_protected_hist_hidden_without_token(
+        self, app_client: TestClient, histogrammer: Histogrammer
+    ) -> None:
+        h = hist.Hist(hist.axis.Regular(4, 0, 4, name="x"), name="secret_hist")
+        hist_id = _add_hist(histogrammer, h, token="secret")
+
+        with app_client.websocket_connect("/ws") as ws:
+            # hist_list must not leak the token-protected histogram
+            ws.send_json({"type": "subscribe", "payload": {"streams": ["hist_list"]}})
+            list_msg = ws.receive_json()
+            assert list_msg["type"] == "hist_list"
+            assert all(
+                item["hist_id"] != hist_id for item in list_msg["payload"]["items"]
+            )
+
+            # data/meta must be treated as not found
+            ws.send_json(
+                {
+                    "type": "get_hist",
+                    "payload": {"hist_id": hist_id, "selection": {}},
+                }
+            )
+            err = ws.receive_json()
+            assert err["type"] == "error"
+            assert err["payload"]["code"] == "NOT_FOUND"
+
+    def test_token_protected_hist_visible_with_token(
+        self, app_client: TestClient, histogrammer: Histogrammer
+    ) -> None:
+        h = hist.Hist(hist.axis.Regular(4, 0, 4, name="x"), name="secret_hist")
+        hist_id = _add_hist(histogrammer, h, token="secret")
+
+        with app_client.websocket_connect("/ws?token=secret") as ws:
+            ws.send_json({"type": "subscribe", "payload": {"streams": ["hist_list"]}})
+            list_msg = ws.receive_json()
+            assert any(
+                item["hist_id"] == hist_id for item in list_msg["payload"]["items"]
+            )
+
+            ws.send_json(
+                {
+                    "type": "get_hist",
+                    "payload": {"hist_id": hist_id, "selection": {}},
+                }
+            )
+            meta = ws.receive_json()
+            data = ws.receive_json()
+            assert meta["type"] == "hist_meta"
+            assert data["type"] == "hist_data"
+            assert data["payload"]["hist_id"] == hist_id
 
     def test_message_envelope_structure(
         self, app_client: TestClient, histogrammer: Histogrammer


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## The leak

Histograms can be created with an access `token`. The gRPC server enforces it (`_get_entry` returns `None` on token mismatch -> `NOT_FOUND`), and the dashboard **REST** endpoints honor it too: they 404 when the `?token=` query param is missing or wrong.

The dashboard **WebSocket** path (`/ws`) did **not** check tokens at all. `subscribe_hist` / `get_hist` -> `_make_hist_request` only checked existence, and `_send_hist_meta` / `_send_hist_data` / `_send_hist_list` exposed the metadata and contents of token-protected histograms to any connected WS client. So a histogram that is hidden over REST without the token was fully readable over the WebSocket.

## The fix

- Read a connection-level `token` from the `?token=` query param on the `/ws` endpoint (mirroring the existing REST convention) and store it on the per-connection `_ClientState`.
- Add a shared `_visible_entry(histogrammer, hist_id, token)` helper that resolves an entry and returns `None` (i.e. "not found") on either a missing entry or a token mismatch. Both REST and WS now use it, so the two paths can't drift apart again.
- Every WS lookup by `hist_id` (`_make_hist_request`, `_send_hist_meta`, `_send_hist_data`, and the per-subscription loop in `_push_to_client`) now treats a token mismatch exactly like NOT_FOUND.
- `_send_hist_list` filters out token-protected entries the connection isn't authorized to see (entries with `token is None` remain public).
- `_ClientState` keeps its identity-based hashing (`@dataclass(eq=False)`); the added `token` field doesn't affect that.

`_send_stats` still uses global stats (`token=None`) as before; scoping aggregate stats per-token is out of scope here and lower priority than the data/list/meta leak.

## Trust-model change (proposal — open to discussion)

This makes the dashboard WS consistent with REST and the gRPC server: token-protected histograms are only visible to clients presenting the matching token. Note the current Svelte frontend (`dashboard/ui/src/lib/stores/websocket.ts`) connects to `/ws` **without** a token, so after this change token-protected histograms will no longer appear in the live dashboard until the frontend is taught to pass `?token=` (the REST lookup form already collects a token). That's the intended behavior — they shouldn't be shown without authorization — but it is a visible behavior change, hence flagging it as a proposal.

## Tests

Added two WS tests mirroring the existing token-scoped REST tests: a token-protected hist is hidden from `hist_list` and returns `NOT_FOUND` on `get_hist` without a token, and is visible/readable when the connection presents `?token=`. `uv run pytest tests/test_dashboard -q` -> 38 passed. `uvx ty check src` adds no new diagnostics (bridge.py is clean).

Part of #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
