### PR TITLE
refactor: drop redundant prune removal and dedupe logging interceptor

### DIFF
--- a/src/histserv/callbacks.py
+++ b/src/histserv/callbacks.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta, timezone
 
 from histserv.logging import fmt_callback_logger_msg
 from histserv.service import Histogrammer, logger
-from histserv.util import bytes_repr
+from histserv.util import bytes_repr, timedelta_repr
 
 
 async def prune_old_hists(
@@ -20,12 +20,11 @@ async def prune_old_hists(
                 fmt_callback_logger_msg(
                     callback_method="prune_old_hists",
                     msg=(
-                        f"dropping histogram ({hist_id}) because it hasn't "
-                        f"been accessed since {delta}"
+                        f"dropping idle histogram ({hist_id}); "
+                        f"not accessed for at least {timedelta_repr(delta)}"
                     ),
                 )
             )
-            histogrammer._entries.pop(hist_id, None)
 
         await asyncio.sleep(interval.total_seconds())
 

--- a/src/histserv/service.py
+++ b/src/histserv/service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import resource
 import time
 import typing as tp
@@ -55,67 +56,48 @@ class LoggingInterceptor(grpc.aio.ServerInterceptor):
 
         async def logging_wrapper(request, context):
             started = time.perf_counter()
-            debug_enabled = logger.isEnabledFor(10)
-            error_enabled = logger.isEnabledFor(40)
+            debug_enabled = logger.isEnabledFor(logging.DEBUG)
+            error_enabled = logger.isEnabledFor(logging.ERROR)
             request_size = request.ByteSize() if (debug_enabled or error_enabled) else 0
+
+            def _log(level: int, msg: str) -> None:
+                hist_id = getattr(request, "hist_id", None)
+                if isinstance(hist_id, str) and hist_id:
+                    logger.log(
+                        level,
+                        fmt_rpc_logger_msg(
+                            rpc_method=rpc_method, hist_id=hist_id, msg=msg
+                        ),
+                    )
+                else:
+                    logger.log(
+                        level,
+                        fmt_rpc_logger_msg_no_hist_id(
+                            rpc_method=rpc_method, msg=msg
+                        ),
+                    )
 
             try:
                 response = await handler.unary_unary(request, context)
             except Exception:
                 if error_enabled:
                     duration = time.perf_counter() - started
-                    hist_id = getattr(request, "hist_id", None)
-                    if isinstance(hist_id, str) and hist_id:
-                        logger.error(
-                            fmt_rpc_logger_msg(
-                                rpc_method=rpc_method,
-                                hist_id=hist_id,
-                                msg=(
-                                    f"request={bytes_repr(request_size)}, "
-                                    f"duration={duration_repr(duration)}, "
-                                    "response=<error>"
-                                ),
-                            )
-                        )
-                    else:
-                        logger.error(
-                            fmt_rpc_logger_msg_no_hist_id(
-                                rpc_method=rpc_method,
-                                msg=(
-                                    f"request={bytes_repr(request_size)}, "
-                                    f"duration={duration_repr(duration)}, "
-                                    "response=<error>"
-                                ),
-                            )
-                        )
+                    _log(
+                        logging.ERROR,
+                        f"request={bytes_repr(request_size)}, "
+                        f"duration={duration_repr(duration)}, "
+                        "response=<error>",
+                    )
                 raise
 
             if debug_enabled:
                 duration = time.perf_counter() - started
-                hist_id = getattr(request, "hist_id", None)
-                if isinstance(hist_id, str) and hist_id:
-                    logger.debug(
-                        fmt_rpc_logger_msg(
-                            rpc_method=rpc_method,
-                            hist_id=hist_id,
-                            msg=(
-                                f"request={bytes_repr(request_size)}, "
-                                f"response={bytes_repr(response.ByteSize())}, "
-                                f"duration={duration_repr(duration)}"
-                            ),
-                        )
-                    )
-                else:
-                    logger.debug(
-                        fmt_rpc_logger_msg_no_hist_id(
-                            rpc_method=rpc_method,
-                            msg=(
-                                f"request={bytes_repr(request_size)}, "
-                                f"response={bytes_repr(response.ByteSize())}, "
-                                f"duration={duration_repr(duration)}"
-                            ),
-                        )
-                    )
+                _log(
+                    logging.DEBUG,
+                    f"request={bytes_repr(request_size)}, "
+                    f"response={bytes_repr(response.ByteSize())}, "
+                    f"duration={duration_repr(duration)}",
+                )
             return response
 
         return grpc.unary_unary_rpc_method_handler(


### PR DESCRIPTION
:robot: _AI text below_ :robot:

This PR contains two focused, pure-refactor cleanups with no behavior changes.

## Change A — remove dead double-pop + fix misleading log in `prune_old_hists`

`Histogrammer.prune_entries_older_than` already pops each expired entry from
`self._entries` before appending its id to the returned list. The loop in
`prune_old_hists` that consumed those ids then called
`histogrammer._entries.pop(hist_id, None)` a second time — a no-op on an entry
that no longer exists. That redundant line is removed.

The log message was also misleading: it rendered the age *threshold* timedelta
(e.g. `1 day, 0:00:00`) with the text "hasn't been accessed since", making it
look like a timestamp. The new wording is
`"dropping idle histogram ({hist_id}); not accessed for at least {timedelta_repr(delta)}"`
which is unambiguous and uses the existing `histserv.util.timedelta_repr` helper
for a clean duration string (e.g. `1.00 day`).

## Change B — deduplicate `LoggingInterceptor.logging_wrapper` + drop magic numbers

The inner `logging_wrapper` in `LoggingInterceptor.intercept_service` duplicated
the same "format with `hist_id` if present, else without" branching four times
(once per log call: error path × 2, debug path × 2). A small local helper
`_log(level, msg)` now owns that branch; the error and debug call sites each
reduce to a single `_log(...)` call.

The level checks `logger.isEnabledFor(10)` / `logger.isEnabledFor(40)` are
replaced with `logger.isEnabledFor(logging.DEBUG)` / `logger.isEnabledFor(logging.ERROR)`
(standard `import logging` added). Same numeric values, but now self-documenting.

## Validation

- `uvx ty check src` — the two pre-existing `invalid-argument-type` errors in
  `util.py` are unchanged; no new diagnostics introduced.
- `uv run pytest tests/test_grpc_integration.py -q` — **55 passed**.

Part of #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
