### PR TITLE
fix: stored ChunkedHist chunks must own their memory

### DIFF
--- a/src/histserv/chunked_hist.py
+++ b/src/histserv/chunked_hist.py
@@ -250,7 +250,7 @@ class ChunkedHist:
         )
         source_view = source.view(flow=True)
         if not chunked.chunk_axes:
-            chunked._save_chunk_view((), np.ascontiguousarray(source_view))
+            chunked._save_chunk_view((), source_view)
             return chunked
 
         if not any(spec.known_keys for spec in chunked.chunk_axes):
@@ -270,7 +270,7 @@ class ChunkedHist:
                 key_values.append(spec.known_keys[key_index])
             chunked._save_chunk_view(
                 tuple(key_values),
-                np.ascontiguousarray(source_view[tuple(selector)]),
+                source_view[tuple(selector)],
             )
 
         return chunked
@@ -293,13 +293,14 @@ class ChunkedHist:
 
     def _save_chunk_view(self, key: ChunkKey, chunk_view: np.ndarray) -> None:
         array = _validate_dense_view(
-            np.ascontiguousarray(chunk_view),
+            chunk_view,
             shape=self.dense_view_shape,
             dtype=self.dense_view_dtype,
         )
-        if not array.flags.writeable:
-            array = array.copy()
-        self._chunks[key] = array
+        # Stored chunks must own their memory: callers may pass views into
+        # other histograms' storage (from_hist, __iadd__) or reused scratch
+        # buffers, and later fills mutate stored chunks in place.
+        self._chunks[key] = np.array(array, order="C")
 
     def _remember_chunk_key(self, key: ChunkKey) -> None:
         for spec, key_part in zip(self.chunk_axes, key, strict=True):
@@ -365,7 +366,7 @@ class ChunkedHist:
             dense_hist.fill(**dense_kwargs)
             existing = self._chunks.get(chunk_key)
             if existing is None:
-                self._save_chunk_view(chunk_key, dense_view.copy(order="C"))
+                self._save_chunk_view(chunk_key, dense_view)
                 self._remember_chunk_key(chunk_key)
             else:
                 existing[...] = dense_view
@@ -592,7 +593,7 @@ class ChunkedHist:
         for result_spec in result.chunk_axes:
             result_spec.known_keys = keys_by_axis[result_spec.name]
         for key in matching_keys:
-            result._save_chunk_view(key, self._chunks[key].copy(order="C"))
+            result._save_chunk_view(key, self._chunks[key])
         return result
 
     def copy(self) -> ChunkedHist:

--- a/tests/test_chunked_hist.py
+++ b/tests/test_chunked_hist.py
@@ -267,3 +267,68 @@ def test_chunked_hist_rejects_array_values_for_categorical_axes(
         match=rf"categorical chunk axis '{axis_name}' only accepts scalar int/str values",
     ):
         chunked.fill(**invalid_fill)
+
+
+def _str_categorical_chunked() -> ChunkedHist:
+    return ChunkedHist(
+        hist.axis.Regular(4, 0, 1, name="x"),
+        hist.axis.StrCategory([], growth=True, name="cat"),
+    )
+
+
+def test_chunked_hist_add_does_not_mutate_operands() -> None:
+    left = _str_categorical_chunked()
+    right = left.empty_like()
+    left.fill(x=[0.2], cat="a")
+    right.fill(x=[0.4], cat="a")
+
+    left_before = left.chunk_view({"cat": "a"}).copy()
+    right_before = right.chunk_view({"cat": "a"}).copy()
+
+    merged = left + right
+
+    np.testing.assert_array_equal(left.chunk_view({"cat": "a"}), left_before)
+    np.testing.assert_array_equal(right.chunk_view({"cat": "a"}), right_before)
+    np.testing.assert_array_equal(
+        merged.chunk_view({"cat": "a"}), left_before + right_before
+    )
+    assert not np.shares_memory(
+        merged.chunk_view({"cat": "a"}), left.chunk_view({"cat": "a"})
+    )
+    assert not np.shares_memory(
+        merged.chunk_view({"cat": "a"}), right.chunk_view({"cat": "a"})
+    )
+
+
+def test_chunked_hist_iadd_copies_chunks_from_other() -> None:
+    accumulator = _str_categorical_chunked()
+    other = accumulator.empty_like()
+    other.fill(x=[0.4], cat="b")
+    other_before = other.chunk_view({"cat": "b"}).copy()
+
+    accumulator += other
+    assert not np.shares_memory(
+        accumulator.chunk_view({"cat": "b"}), other.chunk_view({"cat": "b"})
+    )
+
+    # Filling the accumulator afterwards must not touch `other`.
+    accumulator.fill(x=[0.6], cat="b")
+    np.testing.assert_array_equal(other.chunk_view({"cat": "b"}), other_before)
+
+
+def test_chunked_hist_from_hist_does_not_alias_source_storage() -> None:
+    source = hist.Hist(
+        hist.axis.StrCategory(["a"], growth=True, name="cat"),
+        hist.axis.Regular(4, 0, 1, name="x"),
+    )
+    source.fill(cat=["a"], x=[0.2])
+    source_before = source.view(flow=True).copy()
+
+    chunked = ChunkedHist.from_hist(source)
+    assert not np.shares_memory(
+        chunked.chunk_view({"cat": "a"}), source.view(flow=True)
+    )
+
+    # Filling the chunked copy afterwards must not touch the source hist.
+    chunked.fill(cat="a", x=[0.6])
+    np.testing.assert_array_equal(source.view(flow=True), source_before)


### PR DESCRIPTION
Following #13, this addresses item 1) on that list: it fixes an issue where copying / merging / adding histograms left them sharing memory, leading to accidental modifications on the wrong objects.

---

**🤖 Claude-generated text below 🤖**

---

`_save_chunk_view` only copied its input when the array was read-only, so a
writable C-contiguous input was stored **by reference**. Stored chunks could
then alias memory owned by someone else, and since fills and merges mutate
stored chunks in place, data was corrupted silently. Three reproducible cases:

- `left + right` mutated `left`: `__add__` seeds the result with aliases of
  `left`'s chunks, then `+= right` accumulates into them in place — so adding
  two histograms corrupted the left operand.
- After `a += b`, a later `a.fill(...)` wrote into `b`'s stored chunk.
- `ChunkedHist.from_hist(h)` stored views into `h`'s own buffer whenever the
  selected chunk slice was contiguous (e.g. the chunk axis is the outermost
  axis), so filling the chunked histogram mutated the source `hist.Hist`.

The server's `Fill` path was unaffected only by accident: `np.frombuffer`
arrays are read-only and therefore already hit the copy branch.

**Fix:** `_save_chunk_view` now unconditionally takes ownership via
`np.array(..., order="C")` (which also covers the contiguity previously
handled by `np.ascontiguousarray`). The explicit `.copy()` /
`ascontiguousarray` calls at call sites that compensated for the old behavior
are removed, so every save still costs exactly one copy — including on the
server fill path, where the copy already happened.

**Tests:** three regression tests (one per corruption case) asserting both
value integrity and `np.shares_memory(...) == False`. They fail on `main`.
