### PR TITLE
fix: never configure the root logger on library import

### DIFF
--- a/src/histserv/logging.py
+++ b/src/histserv/logging.py
@@ -36,5 +36,7 @@ def configure_logging(level: int = logging.INFO) -> None:
 
 
 def get_logger(name: str) -> logging.Logger:
-    configure_logging()
+    # Intentionally does NOT call configure_logging(): merely importing the
+    # library must never touch the host application's root logger. Handlers
+    # are only installed when the histserv CLI entry point opts in.
     return logging.getLogger(name)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+_IMPORT_PROBE = """
+import json
+import logging
+
+logging.basicConfig(level=logging.WARNING)
+root = logging.getLogger()
+handler_before = root.handlers[0]
+
+import histserv  # noqa: F401
+
+print(
+    json.dumps(
+        {
+            "level": root.level,
+            "handler_count": len(root.handlers),
+            "handler_preserved": root.handlers[0] is handler_before,
+        }
+    )
+)
+"""
+
+
+def test_import_does_not_reconfigure_root_logger() -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", _IMPORT_PROBE],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    probe = json.loads(result.stdout)
+    assert probe["level"] == 30  # logging.WARNING, as set by the host app
+    assert probe["handler_count"] == 1
+    assert probe["handler_preserved"] is True


### PR DESCRIPTION
Following #13, this addresses item 3) on that list: the library import hijacked logging configuration, which it should not do by default (to leave it fully up to the user). I'd argue the test is not really needed, I left it in but happy to remove.

---

**🤖 Claude-generated text below 🤖**

---

`get_logger()` called `configure_logging()` at import time (via the
module-level `logger` in `service.py`), so a plain `import histserv` in a host
application **cleared the application's root handlers**, installed histserv's
own stream handler, and reset the root level to INFO. Verified: any app that
configures logging before importing histserv loses its configuration.

A library must leave logging configuration to the application.
`get_logger()` now just returns the named logger; `configure_logging()` runs
only from the `histserv` CLI entry point, which already calls it explicitly
with the chosen `--log-level`. CLI behavior is unchanged (startup logs
verified identical).

**Tests:** a subprocess regression test asserting that importing histserv
leaves a pre-configured root logger untouched (fails on `main`).
