### PR TITLE
fix: report the actually bound port when binding port 0

### DIFF
--- a/src/histserv/__main__.py
+++ b/src/histserv/__main__.py
@@ -19,7 +19,7 @@ async def main() -> None:
         "--port",
         default=0,
         type=int,
-        help="TCP port to bind the gRPC server to.",
+        help="TCP port to bind the gRPC server to (0 picks a free port).",
     )
     ap.add_argument(
         "--prune-after-seconds",
@@ -72,7 +72,7 @@ async def main() -> None:
         "server (listening at %s) started with port=%s, "
         "prune_after=%s, prune_interval=%s, stats_interval=%s%s",
         server.address,
-        options.port,
+        server.port,
         timedelta_repr(options.prune_after),
         timedelta_repr(options.prune_interval),
         timedelta_repr(options.stats_interval),

--- a/src/histserv/server.py
+++ b/src/histserv/server.py
@@ -62,11 +62,21 @@ class Server:
 
         self._callbacks: list[asyncio.Task[None]] = []
 
-        self.server.add_insecure_port(self.address)
+        # add_insecure_port returns the actually bound port, which differs
+        # from options.port when it is 0 ("pick any free port").
+        self._port = self.server.add_insecure_port(f"[::]:{self.options.port}")
+        if self._port == 0:
+            raise RuntimeError(
+                f"failed to bind gRPC server to port {self.options.port}"
+            )
+
+    @property
+    def port(self) -> int:
+        return self._port
 
     @property
     def address(self) -> str:
-        return f"[::]:{self.options.port}"
+        return f"[::]:{self._port}"
 
     async def start(self) -> None:
         if self._started:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import socket
 import threading
 from collections.abc import Iterator
 
@@ -12,7 +11,7 @@ from histserv.server import Server, ServerOptions
 
 
 class GrpcServerThread:
-    def __init__(self, port: int) -> None:
+    def __init__(self, port: int = 0) -> None:
         self.port = port
         self._loop: asyncio.AbstractEventLoop | None = None
         self._server: Server | None = None
@@ -60,6 +59,8 @@ class GrpcServerThread:
 
     async def _start_server(self) -> None:
         self._server = Server(options=ServerOptions(port=self.port))
+        # With port=0 the OS picks a free port; expose the bound one.
+        self.port = self._server.port
         await self._server.start()
 
     async def _stop_server(self) -> None:
@@ -71,11 +72,9 @@ class GrpcServerThread:
 
 @pytest.fixture
 def grpc_server() -> Iterator[GrpcServerThread]:
-    with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as sock:
-        sock.bind(("::1", 0))
-        port = sock.getsockname()[1]
-
-    server = GrpcServerThread(port=port)
+    # port=0 lets the server bind any free port, avoiding the race of
+    # probing for a free port first and binding it later.
+    server = GrpcServerThread()
     server.start()
     yield server
     server.stop()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import asyncio
+
+from histserv.server import Server, ServerOptions
+
+
+def test_ephemeral_port_is_reported() -> None:
+    async def run() -> None:
+        server = Server(options=ServerOptions(port=0))
+        await server.start()
+        try:
+            assert server.port != 0
+            assert server.address == f"[::]:{server.port}"
+        finally:
+            await server.stop(grace=0)
+
+    asyncio.run(run())
+
+
+def test_explicit_port_is_kept() -> None:
+    async def run() -> None:
+        server = Server(options=ServerOptions(port=0))
+        await server.start()
+        try:
+            # Grab the port the first server got, release it, and rebind
+            # explicitly to show port/address reflect the requested port.
+            port = server.port
+        finally:
+            await server.stop(grace=0)
+
+        explicit = Server(options=ServerOptions(port=port))
+        await explicit.start()
+        try:
+            assert explicit.port == port
+            assert explicit.address == f"[::]:{port}"
+        finally:
+            await explicit.stop(grace=0)
+
+    asyncio.run(run())


### PR DESCRIPTION
Following #13, this addresses item 4) on that list: now the server reports which port it actually listens on when it starts with an automatically assigned port.

---

**🤖 Claude-generated text below 🤖**

---

The return value of `add_insecure_port()` — the actually bound port — was
ignored. Running `histserv` with the default `--port 0` bound an ephemeral
port and logged `listening at [::]:0`, leaving no way to discover where the
server listens.

- `Server` stores the bound port, exposes it as `Server.port`, and raises if
  binding fails (gRPC returns 0 in that case, previously silent).
- `Server.address` and the CLI startup log now report the real port:
  `listening at [::]:62012 ... port=62012` instead of `[::]:0 ... port=0`.
- `--port` help text documents that 0 picks a free port.
- The test fixture previously probed for a free port with a throwaway socket
  and rebound it later (a bind race under parallel test runs); it now uses
  port 0 and reads `Server.port`.

**Tests:** two new tests (ephemeral port is nonzero and reflected in
`address`; explicit port is kept). The whole integration suite now exercises
the port-0 path via the fixture.