### PR TITLE
fix: dashboard live views: tokens over WS, per-slice data keys, resubscribe on reconnect

### DIFF
--- a/src/histserv/dashboard/bridge.py
+++ b/src/histserv/dashboard/bridge.py
@@ -31,6 +31,10 @@ _PUSH_LOOP_INTERVAL = 0.25  # how often the push loop wakes up
 class _HistRequest:
     hist_id: str
     selection_items: tuple[tuple[str, ChunkScalar], ...] = ()
+    # Access token this subscription was made with. Kept per request (not per
+    # connection) so one WS connection can watch histograms with different
+    # tokens; falls back to the connection's ?token= when the message has none.
+    token: str | None = None
 
     @property
     def selection(self) -> dict[str, ChunkScalar]:
@@ -222,7 +226,16 @@ def _make_hist_request(
             (axis_name, exact_key[index])
             for index, axis_name in enumerate(entry.hist.chunk_axis_names)
         ),
+        token=token,
     )
+
+
+def _effective_token(state: _ClientState, payload: dict) -> str | None:
+    """Per-message token if provided, else the connection-level ?token=."""
+    token = payload.get("token")
+    if isinstance(token, str) and token:
+        return token
+    return state.token
 
 
 async def _send_ws_error(state: _ClientState, *, message: str, code: str) -> None:
@@ -260,12 +273,13 @@ async def _handle_client_message(
     elif msg_type == "subscribe_hist":
         hist_id = payload.get("hist_id")
         if hist_id:
+            request_token = _effective_token(state, payload)
             try:
                 hist_request = _make_hist_request(
                     hist_id,
                     payload.get("selection"),
                     histogrammer,
-                    state.token,
+                    request_token,
                 )
             except KeyError:
                 await _send_ws_error(
@@ -291,7 +305,7 @@ async def _handle_client_message(
                 )
                 return
             state.hist_subscriptions[hist_request] = max(0.1, rate_hz)
-            await _send_hist_meta(state, hist_id, histogrammer)
+            await _send_hist_meta(state, hist_id, histogrammer, token=request_token)
             await _send_hist_data(state, hist_request, histogrammer)
             state.last_hist_push[hist_request] = time.time()
 
@@ -320,12 +334,13 @@ async def _handle_client_message(
     elif msg_type == "get_hist":
         hist_id = payload.get("hist_id")
         if hist_id:
+            request_token = _effective_token(state, payload)
             try:
                 hist_request = _make_hist_request(
                     hist_id,
                     payload.get("selection"),
                     histogrammer,
-                    state.token,
+                    request_token,
                 )
             except KeyError:
                 await _send_ws_error(
@@ -341,7 +356,7 @@ async def _handle_client_message(
                     code="INVALID_SELECTION",
                 )
                 return
-            await _send_hist_meta(state, hist_id, histogrammer)
+            await _send_hist_meta(state, hist_id, histogrammer, token=request_token)
             await _send_hist_data(state, hist_request, histogrammer)
 
 
@@ -370,7 +385,7 @@ async def _push_to_client(
         if now - last < min_interval:
             continue
 
-        entry = _visible_entry(histogrammer, hist_request.hist_id, state.token)
+        entry = _visible_entry(histogrammer, hist_request.hist_id, hist_request.token)
         if entry is None:
             await _send_ws_error(
                 state,
@@ -418,9 +433,13 @@ async def _send_hist_list(state: _ClientState, histogrammer: Histogrammer) -> No
 
 
 async def _send_hist_meta(
-    state: _ClientState, hist_id: str, histogrammer: Histogrammer
+    state: _ClientState,
+    hist_id: str,
+    histogrammer: Histogrammer,
+    *,
+    token: str | None,
 ) -> None:
-    entry = _visible_entry(histogrammer, hist_id, state.token)
+    entry = _visible_entry(histogrammer, hist_id, token)
     if entry is None:
         await _send_ws_error(
             state,
@@ -436,7 +455,7 @@ async def _send_hist_meta(
 async def _send_hist_data(
     state: _ClientState, hist_request: _HistRequest, histogrammer: Histogrammer
 ) -> None:
-    entry = _visible_entry(histogrammer, hist_request.hist_id, state.token)
+    entry = _visible_entry(histogrammer, hist_request.hist_id, hist_request.token)
     if entry is None:
         await _send_ws_error(
             state,

--- a/src/histserv/dashboard/ui/src/__tests__/HistogramView.test.ts
+++ b/src/histserv/dashboard/ui/src/__tests__/HistogramView.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render } from '@testing-library/svelte'
-import { histogramData } from '../lib/stores/histogramData'
+import { histKey, histogramData } from '../lib/stores/histogramData'
 import { histogramMeta } from '../lib/stores/histogramMeta'
 import type { HistDataPayload, HistMetaPayload } from '../lib/types/protocol'
 
@@ -9,6 +9,7 @@ vi.mock('../lib/stores/websocket', () => ({
   wsStatus: { subscribe: vi.fn(() => () => {}) },
   send: vi.fn(),
   onMessage: vi.fn(() => () => {}),
+  onOpen: vi.fn(() => () => {}),
 }))
 
 // Import component after mocking
@@ -59,7 +60,7 @@ describe('HistogramView', () => {
   })
 
   it('renders histogram name when data available', () => {
-    histogramData.set(new Map([['test123', mockData]]))
+    histogramData.set(new Map([[histKey('test123', {}), mockData]]))
     histogramMeta.set(new Map([['test123', mockMeta]]))
     const { getByText } = render(HistogramView, {
       props: { hist_id: 'test123', selection: {}, meta: mockMeta },
@@ -68,7 +69,7 @@ describe('HistogramView', () => {
   })
 
   it('renders histogram label', () => {
-    histogramData.set(new Map([['test123', mockData]]))
+    histogramData.set(new Map([[histKey('test123', {}), mockData]]))
     histogramMeta.set(new Map([['test123', mockMeta]]))
     const { getByText } = render(HistogramView, {
       props: { hist_id: 'test123', selection: {}, meta: mockMeta },
@@ -77,7 +78,7 @@ describe('HistogramView', () => {
   })
 
   it('renders dimension description', () => {
-    histogramData.set(new Map([['test123', mockData]]))
+    histogramData.set(new Map([[histKey('test123', {}), mockData]]))
     histogramMeta.set(new Map([['test123', mockMeta]]))
     const { getByText } = render(HistogramView, {
       props: { hist_id: 'test123', selection: {}, meta: mockMeta },
@@ -87,7 +88,7 @@ describe('HistogramView', () => {
   })
 
   it('renders svg chart element when data available', () => {
-    histogramData.set(new Map([['test123', mockData]]))
+    histogramData.set(new Map([[histKey('test123', {}), mockData]]))
     histogramMeta.set(new Map([['test123', mockMeta]]))
     const { container } = render(HistogramView, {
       props: { hist_id: 'test123', selection: {}, meta: mockMeta },

--- a/src/histserv/dashboard/ui/src/__tests__/histogramData.test.ts
+++ b/src/histserv/dashboard/ui/src/__tests__/histogramData.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { get } from 'svelte/store'
+
+// Mock WebSocket before importing stores
+class MockWS {
+  static OPEN = 1
+  readyState = MockWS.OPEN
+  onopen: (() => void) | null = null
+  onmessage: ((e: { data: string }) => void) | null = null
+  onclose: (() => void) | null = null
+  onerror: (() => void) | null = null
+  sent: string[] = []
+
+  constructor(public url: string) {
+    MockWS.instance = this
+  }
+
+  send(data: string) {
+    this.sent.push(data)
+  }
+
+  close() {
+    this.onclose?.()
+  }
+
+  static instance: MockWS
+}
+
+vi.stubGlobal('WebSocket', MockWS)
+Object.defineProperty(globalThis, 'location', {
+  value: { protocol: 'http:', host: 'localhost' },
+  writable: true,
+})
+
+// Import after mocking
+const { histKey, histogramData, subscribeHist, unsubscribeHist } =
+  await import('../lib/stores/histogramData')
+
+function sentMessages(): { type: string; payload: Record<string, unknown> }[] {
+  return MockWS.instance.sent.map((raw) => JSON.parse(raw))
+}
+
+function receive(payload: Record<string, unknown>) {
+  MockWS.instance.onmessage?.({
+    data: JSON.stringify({ type: 'hist_data', ts: 1000, payload }),
+  })
+}
+
+describe('histKey', () => {
+  it('is independent of selection key order', () => {
+    expect(histKey('h', { a: 1, b: 'x' })).toBe(histKey('h', { b: 'x', a: 1 }))
+  })
+
+  it('distinguishes different selections of the same histogram', () => {
+    expect(histKey('h', { cat: 'a' })).not.toBe(histKey('h', { cat: 'b' }))
+  })
+})
+
+describe('histogramData store', () => {
+  beforeEach(() => {
+    MockWS.instance?.onopen?.()
+    MockWS.instance.sent = []
+    histogramData.set(new Map())
+  })
+
+  it('keeps different selections of the same histogram separately', () => {
+    receive({ hist_id: 'h', selection: { cat: 'a' }, values: [1], version: 1 })
+    receive({ hist_id: 'h', selection: { cat: 'b' }, values: [2], version: 1 })
+
+    const data = get(histogramData)
+    expect(data.get(histKey('h', { cat: 'a' }))?.values).toEqual([1])
+    expect(data.get(histKey('h', { cat: 'b' }))?.values).toEqual([2])
+  })
+
+  it('subscribeHist sends the token only when set', () => {
+    subscribeHist('h', { cat: 'a' }, 'secret')
+    subscribeHist('h', { cat: 'b' })
+
+    const [withToken, withoutToken] = sentMessages()
+    expect(withToken.payload.token).toBe('secret')
+    expect('token' in withoutToken.payload).toBe(false)
+
+    unsubscribeHist('h', { cat: 'a' })
+    unsubscribeHist('h', { cat: 'b' })
+  })
+
+  it('unsubscribeHist drops only the matching selection', () => {
+    receive({ hist_id: 'h', selection: { cat: 'a' }, values: [1], version: 1 })
+    receive({ hist_id: 'h', selection: { cat: 'b' }, values: [2], version: 1 })
+
+    unsubscribeHist('h', { cat: 'a' })
+
+    const data = get(histogramData)
+    expect(data.has(histKey('h', { cat: 'a' }))).toBe(false)
+    expect(data.get(histKey('h', { cat: 'b' }))?.values).toEqual([2])
+  })
+
+  it('re-subscribes active histogram subscriptions on reconnect', () => {
+    vi.useFakeTimers()
+    try {
+      subscribeHist('h', { cat: 'a' }, 'secret', 2.0)
+      const initial = MockWS.instance
+
+      // Drop the connection; the store reconnects after a delay.
+      initial.onclose?.()
+      vi.advanceTimersByTime(5000)
+      expect(MockWS.instance).not.toBe(initial) // a new socket was opened
+      MockWS.instance.onopen?.()
+
+      // The new connection carries the subscription again.
+      const resent = sentMessages().filter((m) => m.type === 'subscribe_hist')
+      expect(resent).toHaveLength(1)
+      expect(resent.at(-1)?.payload).toMatchObject({
+        hist_id: 'h',
+        selection: { cat: 'a' },
+        token: 'secret',
+        rate_limit_hz: 2.0,
+      })
+
+      unsubscribeHist('h', { cat: 'a' })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/src/histserv/dashboard/ui/src/lib/components/HistogramView.svelte
+++ b/src/histserv/dashboard/ui/src/lib/components/HistogramView.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
   import { onMount, onDestroy, createEventDispatcher } from 'svelte'
-  import { histogramData, subscribeHist, unsubscribeHist } from '../stores/histogramData'
+  import { histKey, histogramData, subscribeHist, unsubscribeHist } from '../stores/histogramData'
   import { renderHistogram } from '../d3-histogram'
   import type { HistMetaPayload } from '../types/protocol'
 
   export let hist_id: string
   export let selection: Record<string, string | number>
   export let meta: HistMetaPayload
+  export let token: string | null = null
 
   const dispatch = createEventDispatcher<{ close: void }>()
 
@@ -14,14 +15,14 @@
   let lastVersion: number | null = null
 
   onMount(() => {
-    subscribeHist(hist_id, selection)
+    subscribeHist(hist_id, selection, token)
   })
 
   onDestroy(() => {
     unsubscribeHist(hist_id, selection)
   })
 
-  $: data = $histogramData.get(hist_id) ?? null
+  $: data = $histogramData.get(histKey(hist_id, selection)) ?? null
 
   // Re-render only when version changes (new data arrived)
   $: if (container && data && data.version !== lastVersion) {

--- a/src/histserv/dashboard/ui/src/lib/components/Layout.svelte
+++ b/src/histserv/dashboard/ui/src/lib/components/Layout.svelte
@@ -10,6 +10,7 @@
   interface SliceView {
     id: string
     hist_id: string
+    token: string | null
     selection: Record<string, string | number>
     meta: HistMetaPayload
   }
@@ -24,11 +25,11 @@
       meta: HistMetaPayload
     }>,
   ) {
-    const { hist_id, selection, meta } = event.detail
+    const { hist_id, token, selection, meta } = event.detail
     // Use hist_id + serialized selection as a unique key so the same slice isn't duplicated
     const id = `${hist_id}:${JSON.stringify(selection)}`
     if (views.some((v) => v.id === id)) return
-    views = [...views, { id, hist_id, selection, meta }]
+    views = [...views, { id, hist_id, token, selection, meta }]
   }
 
   function removeView(id: string) {
@@ -57,6 +58,7 @@
         {#each views as view (view.id)}
           <HistogramView
             hist_id={view.hist_id}
+            token={view.token}
             selection={view.selection}
             meta={view.meta}
             on:close={() => removeView(view.id)}

--- a/src/histserv/dashboard/ui/src/lib/stores/histogramData.ts
+++ b/src/histserv/dashboard/ui/src/lib/stores/histogramData.ts
@@ -1,38 +1,84 @@
 import { writable } from 'svelte/store'
 import type { HistDataPayload } from '../types/protocol'
-import { onMessage, send } from './websocket'
+import { onMessage, onOpen, send } from './websocket'
 import { histogramMeta } from './histogramMeta'
 
-// Map from hist_id to latest data payload
+export type Selection = Record<string, string | number>
+
+// Canonical key for one histogram slice. Selections are serialized as sorted
+// [axis, value] pairs so client-built and server-echoed selections agree
+// regardless of key order, and so two views of the same histogram with
+// different selections never collide.
+export function histKey(hist_id: string, selection: Selection): string {
+  const entries = Object.entries(selection).sort(([a], [b]) => a.localeCompare(b))
+  return `${hist_id}:${JSON.stringify(entries)}`
+}
+
+// Map from histKey to latest data payload
 export const histogramData = writable<Map<string, HistDataPayload>>(new Map())
+
+// Live subscriptions by key, kept so reconnects can re-establish the
+// server-side subscription state that is lost when the connection drops.
+interface HistSubscription {
+  hist_id: string
+  selection: Selection
+  token: string | null
+  rate_limit_hz: number
+}
+const _subscriptions = new Map<string, HistSubscription>()
+
+function _sendSubscribe(sub: HistSubscription) {
+  send({
+    type: 'subscribe_hist',
+    payload: {
+      hist_id: sub.hist_id,
+      selection: sub.selection,
+      rate_limit_hz: sub.rate_limit_hz,
+      ...(sub.token ? { token: sub.token } : {}),
+    },
+  })
+}
 
 onMessage('hist_data', (msg) => {
   if (msg.type !== 'hist_data') return
   histogramData.update((m) => {
     const next = new Map(m)
-    next.set(msg.payload.hist_id, msg.payload)
+    next.set(histKey(msg.payload.hist_id, msg.payload.selection), msg.payload)
     return next
   })
 })
 
+onOpen(() => {
+  for (const sub of _subscriptions.values()) _sendSubscribe(sub)
+})
+
 export function subscribeHist(
   hist_id: string,
-  selection: Record<string, string | number>,
+  selection: Selection,
+  token: string | null = null,
   rate_limit_hz = 1.0,
 ) {
-  send({ type: 'subscribe_hist', payload: { hist_id, selection, rate_limit_hz } })
+  const sub: HistSubscription = { hist_id, selection, token, rate_limit_hz }
+  _subscriptions.set(histKey(hist_id, selection), sub)
+  _sendSubscribe(sub)
 }
 
-export function unsubscribeHist(hist_id: string, selection: Record<string, string | number>) {
+export function unsubscribeHist(hist_id: string, selection: Selection) {
+  const key = histKey(hist_id, selection)
+  _subscriptions.delete(key)
   send({ type: 'unsubscribe_hist', payload: { hist_id, selection } })
   histogramData.update((m) => {
     const next = new Map(m)
-    next.delete(hist_id)
+    next.delete(key)
     return next
   })
-  histogramMeta.update((m) => {
-    const next = new Map(m)
-    next.delete(hist_id)
-    return next
-  })
+  // Metadata is per-histogram; drop it only once no view uses the histogram.
+  const stillUsed = [..._subscriptions.values()].some((s) => s.hist_id === hist_id)
+  if (!stillUsed) {
+    histogramMeta.update((m) => {
+      const next = new Map(m)
+      next.delete(hist_id)
+      return next
+    })
+  }
 }

--- a/src/histserv/dashboard/ui/src/lib/stores/websocket.ts
+++ b/src/histserv/dashboard/ui/src/lib/stores/websocket.ts
@@ -16,6 +16,16 @@ const _handlers = new Map<string, Set<MessageHandler>>()
 let _ws: WebSocket | null = null
 let _reconnectTimer: ReturnType<typeof setTimeout> | null = null
 
+// Handlers run on every (re)connect so stores can re-establish server-side
+// subscription state, which is lost when the connection drops.
+type OpenHandler = () => void
+const _openHandlers = new Set<OpenHandler>()
+
+export function onOpen(handler: OpenHandler): () => void {
+  _openHandlers.add(handler)
+  return () => _openHandlers.delete(handler)
+}
+
 function _connect() {
   wsStatus.set('connecting')
   _ws = new WebSocket(WS_URL)
@@ -24,6 +34,7 @@ function _connect() {
     wsStatus.set('open')
     // Re-subscribe to stats stream on reconnect
     send({ type: 'subscribe', payload: { streams: ['stats'] } })
+    for (const handler of _openHandlers) handler()
   }
 
   _ws.onmessage = (event: MessageEvent) => {

--- a/src/histserv/dashboard/ui/src/lib/types/protocol.ts
+++ b/src/histserv/dashboard/ui/src/lib/types/protocol.ts
@@ -122,7 +122,13 @@ export type ServerMessage =
 
 export interface SubscribeHistMsg {
   type: 'subscribe_hist'
-  payload: { hist_id: string; selection: Record<string, string | number>; rate_limit_hz?: number }
+  payload: {
+    hist_id: string
+    selection: Record<string, string | number>
+    rate_limit_hz?: number
+    // Per-subscription access token for token-protected histograms
+    token?: string
+  }
 }
 
 export interface UnsubscribeHistMsg {
@@ -132,7 +138,7 @@ export interface UnsubscribeHistMsg {
 
 export interface GetHistMsg {
   type: 'get_hist'
-  payload: { hist_id: string; selection: Record<string, string | number> }
+  payload: { hist_id: string; selection: Record<string, string | number>; token?: string }
 }
 
 // Used internally by the websocket store on connect — not exposed in UI

--- a/tests/test_dashboard/test_bridge_ws.py
+++ b/tests/test_dashboard/test_bridge_ws.py
@@ -251,6 +251,63 @@ class TestWebSocketProtocol:
             assert data["type"] == "hist_data"
             assert data["payload"]["hist_id"] == hist_id
 
+    def test_per_message_token_grants_access_on_tokenless_connection(
+        self, app_client: TestClient, histogrammer: Histogrammer
+    ) -> None:
+        h = hist.Hist(hist.axis.Regular(4, 0, 4, name="x"), name="secret_hist")
+        hist_id = _add_hist(histogrammer, h, token="secret")
+
+        with app_client.websocket_connect("/ws") as ws:
+            # Without any token the histogram must stay hidden.
+            ws.send_json(
+                {
+                    "type": "subscribe_hist",
+                    "payload": {"hist_id": hist_id, "selection": {}},
+                }
+            )
+            err = ws.receive_json()
+            assert err["type"] == "error"
+            assert err["payload"]["code"] == "NOT_FOUND"
+
+            # The same connection can subscribe by supplying the token
+            # in the message itself.
+            ws.send_json(
+                {
+                    "type": "subscribe_hist",
+                    "payload": {
+                        "hist_id": hist_id,
+                        "selection": {},
+                        "token": "secret",
+                    },
+                }
+            )
+            meta = ws.receive_json()
+            data = ws.receive_json()
+            assert meta["type"] == "hist_meta"
+            assert data["type"] == "hist_data"
+            assert data["payload"]["hist_id"] == hist_id
+
+    def test_per_message_token_must_match(
+        self, app_client: TestClient, histogrammer: Histogrammer
+    ) -> None:
+        h = hist.Hist(hist.axis.Regular(4, 0, 4, name="x"), name="secret_hist")
+        hist_id = _add_hist(histogrammer, h, token="secret")
+
+        with app_client.websocket_connect("/ws") as ws:
+            ws.send_json(
+                {
+                    "type": "get_hist",
+                    "payload": {
+                        "hist_id": hist_id,
+                        "selection": {},
+                        "token": "wrong",
+                    },
+                }
+            )
+            err = ws.receive_json()
+            assert err["type"] == "error"
+            assert err["payload"]["code"] == "NOT_FOUND"
+
     def test_message_envelope_structure(
         self, app_client: TestClient, histogrammer: Histogrammer
     ) -> None:


### PR DESCRIPTION
Following #13, this addresses items 5)–7) on that list: fixing three dashboard bugs that break live histogram views. They relate to token-protected histograms never loading, multiple views of the same histogram overwriting each other, and charts silently freezing after a connection drop.

---

**🤖 Claude-generated text below 🤖**

---

Three related bugs made the dashboard's live histogram views unreliable:

**Token never reached the WebSocket (finding 5).** `HistogramLookup` used
the token for the REST metadata fetch, but `Layout` dropped it and the WS
connected without one — so a token-protected histogram could be looked up
successfully and then hung on "Loading…" forever (the server answers
NOT_FOUND for the subscription). Builds on the token model from PR #9:
`subscribe_hist` / `get_hist` payloads now accept an optional per-message
`token` (falling back to the connection-level `?token=`), the token travels
with each subscription (`_HistRequest.token`), and the UI passes it through
from lookup to live view. Per-message tokens also let one connection watch
histograms protected by *different* tokens, which a single connection-level
token cannot express.

**Data stores were keyed by `hist_id` only (finding 6).** The UI explicitly
supports multiple views of the same histogram with different chunk selections
(`Layout` dedupes on `hist_id + selection`), but `histogramData` /
`histogramMeta` keyed by `hist_id` — so such views clobbered each other's
data, and closing one view deleted the other's. Data is now keyed by
`hist_id` plus the canonical (sorted-axis) selection; metadata is dropped only
when the last view of a histogram closes.

**Reconnects lost all subscriptions (finding 7).** `onopen` only re-subscribed
the `stats` stream; the server keeps subscription state per connection, so
after any WS drop all live histogram subscriptions were silently gone and
charts froze until a full page reload. The store now tracks active
subscriptions and re-establishes them on every (re)connect via an `onOpen`
hook on the websocket store.

**Tests:**
- Python (`tests/test_dashboard/test_bridge_ws.py`): per-message token grants
  access on a token-less connection; wrong per-message token stays NOT_FOUND.
- Frontend (`src/__tests__/histogramData.test.ts`, new): `histKey`
  canonicalization, separate storage per selection, token pass-through,
  unsubscribe drops only its own slice, resubscribe after reconnect.

Note: rebased on top of the merged PR #8 (dashboard async-correctness); the
per-request token lookup composes with PR #8's atomic-capture path in
`_send_hist_data` (entry resolved with `hist_request.token`, then
`capture_plot_json_inputs` + `to_thread`).

Refs: PR #9 (WS token enforcement), PR #8 (bridge changes it may conflict with).