### PR TITLE
fix: minor client and Flush fixes (idle channel, missing h5py)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,9 @@ Homepage = "https://github.com/pfackeldey/histserv"
 Discussions = "https://github.com/pfackeldey/histserv/discussions"
 
 [project.optional-dependencies]
+hdf5 = [
+    "h5py>=3.0",  # needed for the `.flush` RPC on the server
+]
 dashboard = [
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.32.0",

--- a/src/histserv/client.py
+++ b/src/histserv/client.py
@@ -96,7 +96,10 @@ class Client:
 
     def __exit__(self, exc_type, exc_value, traceback) -> None:
         del exc_type, exc_value, traceback
-        self.channel.close()
+        # Only close a channel that was actually created; accessing the
+        # cached_property here would open one just to close it.
+        if "channel" in self.__dict__:
+            self.channel.close()
 
     @cached_property
     def channel(self) -> grpc.Channel:

--- a/src/histserv/service.py
+++ b/src/histserv/service.py
@@ -649,8 +649,16 @@ class Histogrammer(hist_pb2_grpc.HistogrammerServiceServicer):
         request_token = self._request_token(context)
         self._rpc_started(RPC_FLUSH, request_token)
         try:
-            import h5py
-            import uhi.io.hdf5
+            try:
+                import h5py
+                import uhi.io.hdf5
+            except ImportError:
+                await self._abort(
+                    context,
+                    grpc.StatusCode.FAILED_PRECONDITION,
+                    "Flush requires h5py on the server; "
+                    "install the optional extra 'histserv[hdf5]'",
+                )
 
             hist_id = request.hist_id
             destination = request.destination

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from histserv.client import Client
+
+
+def test_exit_without_rpc_does_not_create_channel() -> None:
+    with Client("localhost:1") as client:
+        pass
+    assert "channel" not in client.__dict__
+
+
+def test_exit_closes_created_channel() -> None:
+    with Client("localhost:1") as client:
+        _ = client.channel
+    assert "channel" in client.__dict__

--- a/tests/test_grpc_integration.py
+++ b/tests/test_grpc_integration.py
@@ -546,3 +546,37 @@ def test_remote_slice_snapshot_returns_only_selected_chunks(client: Client) -> N
 
     assert list(sliced.axes["cat"]) == [1]
     np.testing.assert_equal(sliced.sum(flow=True).value, 2.0)
+
+
+def test_flush_writes_hdf5_file_and_removes_hist(
+    client: Client, tmp_path
+) -> None:
+    h5py = pytest.importorskip("h5py")
+    remote_hist = client.init(regular_hist(), token="alice")
+    remote_hist.fill(x=np.array([0.5, 1.5], dtype=np.float32))
+
+    destination = tmp_path / "flushed.h5"
+    remote_hist.flush(str(destination))
+
+    assert not remote_hist.exists()
+    with h5py.File(destination) as h5_file:
+        assert remote_hist.hist_id in h5_file
+
+
+def test_flush_without_h5py_reports_missing_extra(
+    client: Client, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    remote_hist = client.init(regular_hist(), token="alice")
+
+    # Simulate a server installed without the optional hdf5 extra.
+    import sys
+
+    monkeypatch.setitem(sys.modules, "h5py", None)
+    with pytest.raises(
+        grpc.RpcError, match=r"FAILED_PRECONDITION.*histserv\[hdf5\]"
+    ):
+        remote_hist.flush(str(tmp_path / "flushed.h5"))
+    monkeypatch.undo()
+
+    # The histogram is untouched by the failed flush.
+    assert remote_hist.exists()


### PR DESCRIPTION
Following #13, this addresses items 9) and 10) on that list: not opening a connection just to close it, plus better error handling when HDF5 support is missing.

---

**🤖 Claude-generated text below 🤖**

---

Two small independent fixes, one commit each:

**`Client.__exit__` opened a gRPC channel just to close it (finding #9).**
Exiting a `with Client(...)` block that never issued an RPC triggered the
`channel` cached_property, creating a channel solely so it could be closed.
The channel is now only closed if one was actually created.

**`Flush` failed opaquely without h5py (finding #10).** h5py was only a
dev-group dependency, so on a normally installed server the Flush RPC raised
`ModuleNotFoundError`, which reached the client as an opaque internal error.
Flush now aborts with `FAILED_PRECONDITION` and an actionable message
("install the optional extra 'histserv[hdf5]'"), and a new `hdf5` optional
extra documents the dependency.

**Tests:** channel-lifecycle tests for the context manager; a first
happy-path Flush integration test (writes the HDF5 file, removes the
histogram); a missing-h5py test simulating a server without the extra
(fails on `main` with the opaque error).