### PR TITLE
perf: non-blocking Flush, bounded token counters, batched fill_many

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,9 @@ Homepage = "https://github.com/pfackeldey/histserv"
 Discussions = "https://github.com/pfackeldey/histserv/discussions"
 
 [project.optional-dependencies]
+hdf5 = [
+    "h5py>=3.0",  # needed for the `.flush` RPC on the server
+]
 dashboard = [
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.32.0",

--- a/src/histserv/client.py
+++ b/src/histserv/client.py
@@ -96,7 +96,10 @@ class Client:
 
     def __exit__(self, exc_type, exc_value, traceback) -> None:
         del exc_type, exc_value, traceback
-        self.channel.close()
+        # Only close a channel that was actually created; accessing the
+        # cached_property here would open one just to close it.
+        if "channel" in self.__dict__:
+            self.channel.close()
 
     @cached_property
     def channel(self) -> grpc.Channel:

--- a/src/histserv/client.py
+++ b/src/histserv/client.py
@@ -11,6 +11,7 @@ import grpc
 from hist import Hist
 
 from histserv.chunked_hist import (
+    ChunkKey,
     ChunkScalar,
     ChunkedHist,
     _zero_dense_view,
@@ -454,11 +455,19 @@ class RemoteHist:
             ):
                 raise ValueError("all fills in fill_many must use compatible axes")
 
+            # Accumulate fills per distinct chunk key before serializing, so
+            # N fills of the same chunk cost one dense payload instead of N
+            # (the server merges them anyway).
+            grouped: dict[ChunkKey, list[dict[str, tp.Any]]] = {}
+            for chunk_key, dense_kwargs in split_fills:
+                grouped.setdefault(chunk_key, []).append(dense_kwargs)
+
             dense_hist = self._make_dense_hist()
             dense_view = dense_hist.view(flow=True)
-            for chunk_key, dense_kwargs in split_fills:
+            for chunk_key, dense_kwargs_list in grouped.items():
                 try:
-                    dense_hist.fill(**dense_kwargs)
+                    for dense_kwargs in dense_kwargs_list:
+                        dense_hist.fill(**dense_kwargs)
                     chunks.append(
                         serialize_chunk_payload(
                             chunk_key,

--- a/src/histserv/service.py
+++ b/src/histserv/service.py
@@ -675,8 +675,19 @@ class Histogrammer(hist_pb2_grpc.HistogrammerServiceServicer):
                 hist_id=hist_id,
                 request_token=request_token,
             )
-            with h5py.File(destination, "w") as h5_file:
-                uhi.io.hdf5.write(h5_file.create_group(hist_id), entry.hist.to_hist())
+            # Capture an atomic copy on the event loop (same pattern as
+            # Snapshot), then materialize and write the file in a worker
+            # thread so the blocking I/O does not stall other RPCs. The
+            # entry is removed only after the write succeeds.
+            snapshot = entry.hist.copy()
+
+            def _write_hdf5() -> None:
+                with h5py.File(destination, "w") as h5_file:
+                    uhi.io.hdf5.write(
+                        h5_file.create_group(hist_id), snapshot.to_hist()
+                    )
+
+            await asyncio.to_thread(_write_hdf5)
             self._entries.pop(hist_id, None)
             logger.debug(
                 fmt_rpc_logger_msg(

--- a/src/histserv/service.py
+++ b/src/histserv/service.py
@@ -649,8 +649,16 @@ class Histogrammer(hist_pb2_grpc.HistogrammerServiceServicer):
         request_token = self._request_token(context)
         self._rpc_started(RPC_FLUSH, request_token)
         try:
-            import h5py
-            import uhi.io.hdf5
+            try:
+                import h5py
+                import uhi.io.hdf5
+            except ImportError:
+                await self._abort(
+                    context,
+                    grpc.StatusCode.FAILED_PRECONDITION,
+                    "Flush requires h5py on the server; "
+                    "install the optional extra 'histserv[hdf5]'",
+                )
 
             hist_id = request.hist_id
             destination = request.destination

--- a/src/histserv/service.py
+++ b/src/histserv/service.py
@@ -286,11 +286,25 @@ class Histogrammer(hist_pb2_grpc.HistogrammerServiceServicer):
     def entries_snapshot(self) -> tuple[HistogramEntry, ...]:
         return tuple(self._entries.values())
 
+    def _remove_entry(self, hist_id: str) -> None:
+        """Remove a histogram and, if its token is no longer used by any
+        entry, the token's RPC counters — otherwise the per-token Counter
+        grows without bound on a long-lived server. A token with no
+        histograms is unreachable through Stats anyway (NOT_FOUND)."""
+        entry = self._entries.pop(hist_id, None)
+        if entry is None or entry.token is None:
+            return
+        token = entry.token
+        if any(e.token == token for e in self._entries.values()):
+            return
+        for key in [k for k in self._rpc_calls_by_token if k[0] == token]:
+            del self._rpc_calls_by_token[key]
+
     def prune_entries_older_than(self, *, now: datetime, age: timedelta) -> list[str]:
         removed: list[str] = []
         for hist_id, entry in tuple(self._entries.items()):
             if (now - entry.last_access) >= age:
-                self._entries.pop(hist_id, None)
+                self._remove_entry(hist_id)
                 removed.append(hist_id)
         return removed
 
@@ -558,7 +572,7 @@ class Histogrammer(hist_pb2_grpc.HistogrammerServiceServicer):
                     codec=self._request_dense_view_codec(request),
                 )
                 if request.delete_from_server:
-                    self._entries.pop(hist_id, None)
+                    self._remove_entry(hist_id)
                 logger.debug(
                     fmt_rpc_logger_msg(
                         rpc_method=RPC_SNAPSHOT,
@@ -605,7 +619,7 @@ class Histogrammer(hist_pb2_grpc.HistogrammerServiceServicer):
                 hist_id=hist_id,
                 request_token=request_token,
             )
-            self._entries.pop(hist_id, None)
+            self._remove_entry(hist_id)
             logger.debug(
                 fmt_rpc_logger_msg(
                     rpc_method=RPC_DELETE,
@@ -688,7 +702,7 @@ class Histogrammer(hist_pb2_grpc.HistogrammerServiceServicer):
                     )
 
             await asyncio.to_thread(_write_hdf5)
-            self._entries.pop(hist_id, None)
+            self._remove_entry(hist_id)
             logger.debug(
                 fmt_rpc_logger_msg(
                     rpc_method=RPC_FLUSH,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from histserv.client import Client
+
+
+def test_exit_without_rpc_does_not_create_channel() -> None:
+    with Client("localhost:1") as client:
+        pass
+    assert "channel" not in client.__dict__
+
+
+def test_exit_closes_created_channel() -> None:
+    with Client("localhost:1") as client:
+        _ = client.channel
+    assert "channel" in client.__dict__

--- a/tests/test_grpc_integration.py
+++ b/tests/test_grpc_integration.py
@@ -580,3 +580,25 @@ def test_flush_without_h5py_reports_missing_extra(
 
     # The histogram is untouched by the failed flush.
     assert remote_hist.exists()
+
+
+def test_token_rpc_counters_dropped_with_last_histogram(
+    client: Client, grpc_server
+) -> None:
+    first = client.init(regular_hist(), token="alice")
+    second = client.init(regular_hist(), token="alice")
+    first.fill(x=np.array([0.5], dtype=np.float32))
+
+    def alice_counters() -> list[tuple[str, str]]:
+        histogrammer = grpc_server._server.histogrammer
+        return [key for key in histogrammer._rpc_calls_by_token if key[0] == "alice"]
+
+    assert alice_counters()
+
+    # Counters survive while the token still owns a histogram ...
+    first.delete()
+    assert alice_counters()
+
+    # ... and are dropped with its last histogram.
+    second.delete()
+    assert not alice_counters()

--- a/tests/test_grpc_integration.py
+++ b/tests/test_grpc_integration.py
@@ -602,3 +602,45 @@ def test_token_rpc_counters_dropped_with_last_histogram(
     # ... and are dropped with its last histogram.
     second.delete()
     assert not alice_counters()
+
+
+def test_fill_many_sends_one_chunk_per_distinct_key(
+    client: Client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def make_hist() -> Hist:
+        return Hist(
+            hist.axis.Regular(8, 0, 1, name="x"),
+            hist.axis.StrCategory([], growth=True, name="cat"),
+        )
+
+    local_hist = make_hist()
+    remote_hist = client.init(make_hist(), token="alice")
+
+    stub = remote_hist.client.stub
+    captured: list[hist_pb2.FillManyRequest] = []
+    original_fill_many = stub.FillMany
+
+    def spy(request: hist_pb2.FillManyRequest, **kwargs: object):
+        captured.append(request)
+        return original_fill_many(request, **kwargs)
+
+    monkeypatch.setattr(stub, "FillMany", spy)
+
+    fill_calls = [
+        {"x": [0.1], "cat": "a"},
+        {"x": [0.2], "cat": "b"},
+        {"x": [0.3], "cat": "a"},
+        {"x": [0.4], "cat": "a"},
+    ]
+    for fill_kwargs in fill_calls:
+        local_hist.fill(**fill_kwargs)
+    remote_hist.fill_many(fill_calls)
+
+    # Four fills over two distinct chunk keys -> two dense payloads.
+    assert len(captured) == 1
+    assert len(captured[0].chunks) == 2
+
+    remote_snapshot = remote_hist.snapshot()
+    np.testing.assert_equal(
+        remote_snapshot.to_hist().view(flow=True), local_hist.view(flow=True)
+    )

--- a/tests/test_grpc_integration.py
+++ b/tests/test_grpc_integration.py
@@ -546,3 +546,37 @@ def test_remote_slice_snapshot_returns_only_selected_chunks(client: Client) -> N
 
     assert list(sliced.axes["cat"]) == [1]
     np.testing.assert_equal(sliced.sum(flow=True).value, 2.0)
+
+
+def test_flush_writes_hdf5_file_and_removes_hist(
+    client: Client, tmp_path
+) -> None:
+    h5py = pytest.importorskip("h5py")
+    remote_hist = client.init(regular_hist(), token="alice")
+    remote_hist.fill(x=np.array([0.5, 1.5], dtype=np.float32))
+
+    destination = tmp_path / "flushed.h5"
+    remote_hist.flush(str(destination))
+
+    assert not remote_hist.exists()
+    with h5py.File(destination) as h5_file:
+        assert remote_hist.hist_id in h5_file
+
+
+def test_flush_without_h5py_reports_missing_extra(
+    client: Client, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    remote_hist = client.init(regular_hist(), token="alice")
+
+    # Simulate a server installed without the optional hdf5 extra.
+    import sys
+
+    monkeypatch.setitem(sys.modules, "h5py", None)
+    with pytest.raises(
+        grpc.RpcError, match=r"FAILED_PRECONDITION.*histserv\[hdf5\]"
+    ):
+        remote_hist.flush(str(tmp_path / "flushed.h5"))
+    monkeypatch.undo()
+
+    # The histogram is untouched by the failed flush.
+    assert remote_hist.exists()


### PR DESCRIPTION
Following #13, this addresses the remaining performance section (all but the fourth item which was fixed in #8): non-blocking file export, bounded per-token statistics memory, batched fill requests.

**Note:** This builds on #18 to avoid conflicts, so #18 should be merged first (or the two need to be disentangled).

---

**🤖 Claude-generated text below 🤖**

---

Three small performance fixes from the review, one commit each:

**Flush blocked the event loop.** The synchronous h5py write stalled every
concurrent RPC for the duration of the file write. Now follows the pattern
Snapshot uses since PR #8: atomic `ChunkedHist.copy()` on the loop,
materialize + write in a worker thread, entry removed only on success.

**`_rpc_calls_by_token` grew without bound.** One counter per (token, rpc)
was kept forever, even after all of a token's histograms were pruned or
deleted — unbounded memory on a long-lived multi-tenant server. Entry removal
now goes through a `_remove_entry` helper that drops a token's counters with
its last histogram. No observable API change: Stats already answers NOT_FOUND
for a token without histograms, so those counters were unreachable.

**`fill_many` sent one full dense array per fill.** N fills of the same chunk
shipped N full-size payloads that the server merged one by one. The client now
accumulates fills per distinct chunk key and serializes once per key, shrinking
requests proportionally to key repetition. Wire-compatible with existing
servers (they merge chunks either way).

The fourth performance item from the review — torn reads in dashboard plots —
was already fixed by the merged PR #8 (`capture_plot_json_inputs`).

**Tests:** token counters dropped with the last histogram (kept while another
histogram shares the token); fill_many request contains one chunk per distinct
key with values matching a locally filled reference; existing Flush and
randomized duplicate-key fill_many tests cover the refactored paths.